### PR TITLE
Add multilabel ChestX-ray14 task

### DIFF
--- a/pyhealth/datasets/__init__.py
+++ b/pyhealth/datasets/__init__.py
@@ -27,6 +27,7 @@ class SampleSignalDataset:
 
 from .base_dataset import BaseDataset
 from .cardiology import CardiologyDataset
+from .chestxray14 import ChestXray14Dataset
 from .covid19_cxr import COVID19CXRDataset
 from .ehrshot import EHRShotDataset
 from .eicu import eICUDataset

--- a/pyhealth/datasets/chestxray14.py
+++ b/pyhealth/datasets/chestxray14.py
@@ -29,6 +29,7 @@ import urllib.request
 import pandas as pd
 
 from .base_dataset import BaseDataset
+from ..tasks.chestxray14_multilabel_classification import ChestXray14MultilabelClassification
 
 logger = logging.getLogger(__name__)
 
@@ -145,6 +146,19 @@ class ChestXray14Dataset(BaseDataset):
             lines.append(f"\t- Number with {_class}: {num_finding} ({(num_finding / self.__len__()) * 100:.1f}%)")
         lines.append("")
         print("\n".join(lines))
+
+    @property
+    def default_task(self) -> ChestXray14MultilabelClassification:
+        """Returns the default task for this dataset.
+
+        Returns:
+            ChestXray14MultilabelClassification: The default classification task.
+
+        Example:
+            >>> dataset = ChestXray14Dataset()
+            >>> task = dataset.default_task
+        """
+        return ChestXray14MultilabelClassification()
 
     def _download(self, root: str) -> None:
         """Downloads and verifies the ChestX-ray14 dataset files.

--- a/pyhealth/datasets/chestxray14.py
+++ b/pyhealth/datasets/chestxray14.py
@@ -137,9 +137,12 @@ class ChestXray14Dataset(BaseDataset):
         lines.append(f"\t- Dataset: {self.dataset_name}")
         lines.append(f"\t- Number of images: {self.__len__()}")
         lines.append(f"\t- Average number of findings per image: {self._data[self.classes].sum().sum() / self.__len__():.2}")
-        lines.append(f"\t- Number with no finding: {(self._data[self.classes].sum(axis=1) == 0).sum()}")
+        lines.append(f"\t- Max number of findings in an image: {self._data[self.classes].sum(axis=1).max()}")
+        num_no_finding = (self._data[self.classes].sum(axis=1) == 0).sum()
+        lines.append(f"\t- Number with no finding: {num_no_finding} ({(num_no_finding / self.__len__()) * 100:.1}%)")
         for _class in self.classes:
-            lines.append(f"\t- Number with {_class}: {self._data[_class].sum()}")
+            num_finding = self._data[_class].sum()
+            lines.append(f"\t- Number with {_class}: {num_finding} ({(num_finding / self.__len__()) * 100:.1}%)")
         lines.append("")
         print("\n".join(lines))
 

--- a/pyhealth/datasets/chestxray14.py
+++ b/pyhealth/datasets/chestxray14.py
@@ -124,12 +124,12 @@ class ChestXray14Dataset(BaseDataset):
         """
         return self._data.iloc[index]
 
-    def stat(self) -> None:
+    def stats(self) -> None:
         """Prints information on the contents of the dataset
 
         Example:
             >>> dataset = ChestXray14Dataset()
-            >>> dataset.stat()
+            >>> dataset.stats()
         """
         lines = list()
         lines.append("")
@@ -323,5 +323,5 @@ if __name__ == "__main__":
 
     dataset = ChestXray14Dataset(config_path=args.config, download=args.download, partial=args.partial)
 
-    dataset.stat()
+    dataset.stats()
     print(dataset[0])

--- a/pyhealth/datasets/chestxray14.py
+++ b/pyhealth/datasets/chestxray14.py
@@ -305,6 +305,12 @@ class ChestXray14Dataset(BaseDataset):
 
 if __name__ == "__main__":
     logger.setLevel(logging.INFO)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setLevel(logging.INFO)
+        formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", type=str)

--- a/pyhealth/datasets/chestxray14.py
+++ b/pyhealth/datasets/chestxray14.py
@@ -28,7 +28,7 @@ import urllib.request
 
 import pandas as pd
 
-from pyhealth.datasets.base_dataset import BaseDataset
+from .base_dataset import BaseDataset
 
 logger = logging.getLogger(__name__)
 

--- a/pyhealth/datasets/chestxray14.py
+++ b/pyhealth/datasets/chestxray14.py
@@ -136,13 +136,13 @@ class ChestXray14Dataset(BaseDataset):
         lines.append(f"Statistics (partial={self._partial}):")
         lines.append(f"\t- Dataset: {self.dataset_name}")
         lines.append(f"\t- Number of images: {self.__len__()}")
-        lines.append(f"\t- Average number of findings per image: {self._data[self.classes].sum().sum() / self.__len__():.2}")
+        lines.append(f"\t- Average number of findings per image: {self._data[self.classes].sum().sum() / self.__len__():.2f}")
         lines.append(f"\t- Max number of findings in an image: {self._data[self.classes].sum(axis=1).max()}")
         num_no_finding = (self._data[self.classes].sum(axis=1) == 0).sum()
-        lines.append(f"\t- Number with no finding: {num_no_finding} ({(num_no_finding / self.__len__()) * 100:.1}%)")
+        lines.append(f"\t- Number with no finding: {num_no_finding} ({(num_no_finding / self.__len__()) * 100:.1f}%)")
         for _class in self.classes:
             num_finding = self._data[_class].sum()
-            lines.append(f"\t- Number with {_class}: {num_finding} ({(num_finding / self.__len__()) * 100:.1}%)")
+            lines.append(f"\t- Number with {_class}: {num_finding} ({(num_finding / self.__len__()) * 100:.1f}%)")
         lines.append("")
         print("\n".join(lines))
 

--- a/pyhealth/datasets/chestxray14.py
+++ b/pyhealth/datasets/chestxray14.py
@@ -23,7 +23,7 @@ import os
 from pathlib import Path
 import requests
 import tarfile
-from typing import Optional
+from typing import List, Optional
 import urllib.request
 
 import pandas as pd
@@ -46,7 +46,7 @@ class ChestXray14Dataset(BaseDataset):
         __getitem__(index: int): Retrieves a specific image and its metadata.
         stat(): Prints statistics about the dataset's content.
     """
-    classes = ["atelectasis", "cardiomegaly", "consolidation",
+    classes: List[str] = ["atelectasis", "cardiomegaly", "consolidation",
                "edema", "effusion", "emphysema",
                "fibrosis", "hernia", "infiltration",
                "mass", "nodule", "pleural_thickening",

--- a/pyhealth/tasks/__init__.py
+++ b/pyhealth/tasks/__init__.py
@@ -8,6 +8,7 @@ from .cardiology_detect import (
     cardiology_isWA_fn,
 )
 from .chestxray14_binary_classification import ChestXray14BinaryClassification
+from .chestxray14_multilabel_classification import ChestXray14MultilabelClassification
 from .covid19_cxr_classification import COVID19CXRClassification
 from .drug_recommendation import (
     drug_recommendation_eicu_fn,

--- a/pyhealth/tasks/__init__.py
+++ b/pyhealth/tasks/__init__.py
@@ -7,6 +7,7 @@ from .cardiology_detect import (
     cardiology_isCD_fn,
     cardiology_isWA_fn,
 )
+from .chestxray14_binary_classification import ChestXray14BinaryClassification
 from .covid19_cxr_classification import COVID19CXRClassification
 from .drug_recommendation import (
     drug_recommendation_eicu_fn,

--- a/pyhealth/tasks/chestxray14_binary_classification.py
+++ b/pyhealth/tasks/chestxray14_binary_classification.py
@@ -20,7 +20,6 @@ import logging
 from typing import Dict, List
 
 from ..data import Event, Patient
-from ..datasets.chestxray14 import ChestXray14Dataset
 from .base_task import BaseTask
 
 logger = logging.getLogger(__name__)
@@ -34,11 +33,17 @@ class ChestXray14BinaryClassification(BaseTask):
         task_name (str): The name of the task.
         input_schema (Dict[str, str]): The schema for the task input.
         output_schema (Dict[str, str]): The schema for the task output.
+        classes (List[str]): List of diseases that appear in the dataset.
         disease (str): The disease label to classify.
     """
     task_name: str = "ChestXray14BinaryClassification"
     input_schema: Dict[str, str] = {"image": "image"}
     output_schema: Dict[str, str] = {"label": "binary"}
+    classes: List[str] = ["atelectasis", "cardiomegaly", "consolidation",
+               "edema", "effusion", "emphysema",
+               "fibrosis", "hernia", "infiltration",
+               "mass", "nodule", "pleural_thickening",
+               "pneumonia", "pneumothorax"]
 
     def __init__(self, disease: str) -> None:
         """
@@ -51,7 +56,7 @@ class ChestXray14BinaryClassification(BaseTask):
         Raises:
             ValueError: If the specified disease is not a valid class in the dataset.
         """
-        if disease not in ChestXray14Dataset.classes:
+        if disease not in self.classes:
             msg = "Invalid disease!"
             logger.error(msg)
             raise ValueError(msg)

--- a/pyhealth/tasks/chestxray14_binary_classification.py
+++ b/pyhealth/tasks/chestxray14_binary_classification.py
@@ -58,7 +58,7 @@ class ChestXray14BinaryClassification(BaseTask):
 
         self.disease = disease
 
-    def __call__(self, patient: Patient) -> List[Dict[str, str]]:
+    def __call__(self, patient: Patient) -> List[Dict]:
         """
         Generates a binary classification data sample for a single patient.
 
@@ -67,9 +67,9 @@ class ChestXray14BinaryClassification(BaseTask):
                                'chestxray14' event.
 
         Returns:
-            List[Dict[str, str]]: A list containing a single dictionary with:
+            List[Dict]: A list containing a single dictionary with:
                 - 'image': path to the chest X-ray image.
-                - 'label': binary label (as a string) for the specified disease.
+                - 'label': binary label for the specified disease.
 
         Raises:
             ValueError: If the number of chestxray14 events is not exactly one.

--- a/pyhealth/tasks/chestxray14_binary_classification.py
+++ b/pyhealth/tasks/chestxray14_binary_classification.py
@@ -16,11 +16,14 @@ Dataset paper link:
 Author:
     Eric Schrock (ejs9@illinois.edu)
 """
+import logging
 from typing import Dict, List
 
 from ..data import Event, Patient
 from ..datasets.chestxray14 import ChestXray14Dataset
 from .base_task import BaseTask
+
+logger = logging.getLogger(__name__)
 
 class ChestXray14BinaryClassification(BaseTask):
     """

--- a/pyhealth/tasks/chestxray14_binary_classification.py
+++ b/pyhealth/tasks/chestxray14_binary_classification.py
@@ -33,17 +33,11 @@ class ChestXray14BinaryClassification(BaseTask):
         task_name (str): The name of the task.
         input_schema (Dict[str, str]): The schema for the task input.
         output_schema (Dict[str, str]): The schema for the task output.
-        classes (List[str]): List of diseases that appear in the dataset.
         disease (str): The disease label to classify.
     """
     task_name: str = "ChestXray14BinaryClassification"
     input_schema: Dict[str, str] = {"image": "image"}
     output_schema: Dict[str, str] = {"label": "binary"}
-    classes: List[str] = ["atelectasis", "cardiomegaly", "consolidation",
-               "edema", "effusion", "emphysema",
-               "fibrosis", "hernia", "infiltration",
-               "mass", "nodule", "pleural_thickening",
-               "pneumonia", "pneumothorax"]
 
     def __init__(self, disease: str) -> None:
         """
@@ -56,7 +50,8 @@ class ChestXray14BinaryClassification(BaseTask):
         Raises:
             ValueError: If the specified disease is not a valid class in the dataset.
         """
-        if disease not in self.classes:
+        from ..datasets.chestxray14 import ChestXray14Dataset # Avoid circular import
+        if disease not in ChestXray14Dataset.classes:
             msg = "Invalid disease!"
             logger.error(msg)
             raise ValueError(msg)

--- a/pyhealth/tasks/chestxray14_binary_classification.py
+++ b/pyhealth/tasks/chestxray14_binary_classification.py
@@ -80,4 +80,4 @@ class ChestXray14BinaryClassification(BaseTask):
             logger.error(msg)
             raise ValueError(msg)
 
-        return [{"image": events[0]["path"], "label": events[0][self.disease]}]
+        return [{"image": events[0]["path"], "label": int(events[0][self.disease])}]

--- a/pyhealth/tasks/chestxray14_binary_classification.py
+++ b/pyhealth/tasks/chestxray14_binary_classification.py
@@ -16,14 +16,11 @@ Dataset paper link:
 Author:
     Eric Schrock (ejs9@illinois.edu)
 """
-import logging
 from typing import Dict, List
 
-from pyhealth.data.data import Event, Patient
-from pyhealth.datasets.chestxray14 import ChestXray14Dataset
-from pyhealth.tasks.base_task import BaseTask
-
-logger = logging.getLogger(__name__)
+from ..data import Event, Patient
+from ..datasets.chestxray14 import ChestXray14Dataset
+from .base_task import BaseTask
 
 class ChestXray14BinaryClassification(BaseTask):
     """

--- a/pyhealth/tasks/chestxray14_multilabel_classification.py
+++ b/pyhealth/tasks/chestxray14_multilabel_classification.py
@@ -49,6 +49,7 @@ class ChestXray14MultilabelClassification(BaseTask):
         Returns:
             List[Dict]: A list containing a single dictionary with:
                 - 'image': path to the chest X-ray image.
+                - 'path': path to the chest X-ray image (excluded from the input and output schemas and used for testing).
                 - 'labels': a list of labels for diseases present in the image (0-based indices of ChestXray14Dataset.classes).
 
         Raises:
@@ -61,4 +62,4 @@ class ChestXray14MultilabelClassification(BaseTask):
             raise ValueError(msg)
 
         from ..datasets.chestxray14 import ChestXray14Dataset # Avoid circular import
-        return [{"image": events[0]["path"], "labels": [disease for disease in ChestXray14Dataset.classes if int(events[0][disease])]}]
+        return [{"image": events[0]["path"], "path": events[0]["path"], "labels": [disease for disease in ChestXray14Dataset.classes if int(events[0][disease])]}]

--- a/pyhealth/tasks/chestxray14_multilabel_classification.py
+++ b/pyhealth/tasks/chestxray14_multilabel_classification.py
@@ -49,7 +49,7 @@ class ChestXray14MultilabelClassification(BaseTask):
         Returns:
             List[Dict]: A list containing a single dictionary with:
                 - 'image': path to the chest X-ray image.
-                - 'labels': a list of labels for diseases present in the image.
+                - 'labels': a list of labels for diseases present in the image (0-based indices of ChestXray14Dataset.classes).
 
         Raises:
             ValueError: If the number of chestxray14 events is not exactly one.
@@ -61,4 +61,4 @@ class ChestXray14MultilabelClassification(BaseTask):
             raise ValueError(msg)
 
         from ..datasets.chestxray14 import ChestXray14Dataset # Avoid circular import
-        return [{"image": events[0]["path"], "labels": [disease for disease in ChestXray14Dataset.classes if events[0][disease]]}]
+        return [{"image": events[0]["path"], "labels": [i for i, disease in enumerate(ChestXray14Dataset.classes) if events[0][disease]]}]

--- a/pyhealth/tasks/chestxray14_multilabel_classification.py
+++ b/pyhealth/tasks/chestxray14_multilabel_classification.py
@@ -1,0 +1,64 @@
+"""
+PyHealth task for multilabel classification using the ChestX-ray14 dataset.
+
+Dataset link:
+    https://nihcc.app.box.com/v/ChestXray-NIHCC/folder/36938765345
+
+Dataset paper: (please cite if you use this dataset)
+    Xiaosong Wang, Yifan Peng, Le Lu, et al. "ChestX-ray8: Hospital-scale Chest
+    X-ray Database and Benchmarks on Weakly-Supervised Classification and
+    Localization of Common Thorax Diseases." 2017 IEEE Conference on Computer
+    Vision and Pattern Recognition (CVPR), pp. 3462-3471.
+
+Dataset paper link:
+    https://arxiv.org/abs/1705.02315
+
+Author:
+    Eric Schrock (ejs9@illinois.edu)
+"""
+import logging
+from typing import Dict, List
+
+from ..data import Event, Patient
+from .base_task import BaseTask
+
+logger = logging.getLogger(__name__)
+
+class ChestXray14MultilabelClassification(BaseTask):
+    """
+    A PyHealth task class for multilabel classification of all fourteen diseases
+    in the ChestXray14 dataset.
+
+    Attributes:
+        task_name (str): The name of the task.
+        input_schema (Dict[str, str]): The schema for the task input.
+        output_schema (Dict[str, str]): The schema for the task output.
+    """
+    task_name: str = "ChestXray14MultilabelClassification"
+    input_schema: Dict[str, str] = {"image": "image"}
+    output_schema: Dict[str, str] = {"labels": "multilabel"}
+
+    def __call__(self, patient: Patient) -> List[Dict[str, str]]:
+        """
+        Generates a multilabel classification data sample for a single patient.
+
+        Args:
+            patient (Patient): A patient object containing at least one
+                               'chestxray14' event.
+
+        Returns:
+            List[Dict[str, str]]: A list containing a single dictionary with:
+                - 'image': path to the chest X-ray image.
+                - 'labels': a list of binary labels (as strings) for the fourteen classes in ChestXray14Dataset.
+
+        Raises:
+            ValueError: If the number of chestxray14 events is not exactly one.
+        """
+        events: List[Event] = patient.get_events(event_type="chestxray14")
+        if len(events) != 1:
+            msg = f"Expected just 1 event but got {len(events)}!"
+            logger.error(msg)
+            raise ValueError(msg)
+
+        from ..datasets.chestxray14 import ChestXray14Dataset # Avoid circular import
+        return [{"image": events[0]["path"], "labels": [events[0][disease] for disease in ChestXray14Dataset.classes]}]

--- a/pyhealth/tasks/chestxray14_multilabel_classification.py
+++ b/pyhealth/tasks/chestxray14_multilabel_classification.py
@@ -38,7 +38,7 @@ class ChestXray14MultilabelClassification(BaseTask):
     input_schema: Dict[str, str] = {"image": "image"}
     output_schema: Dict[str, str] = {"labels": "multilabel"}
 
-    def __call__(self, patient: Patient) -> List[Dict[str, str]]:
+    def __call__(self, patient: Patient) -> List[Dict]:
         """
         Generates a multilabel classification data sample for a single patient.
 
@@ -47,9 +47,9 @@ class ChestXray14MultilabelClassification(BaseTask):
                                'chestxray14' event.
 
         Returns:
-            List[Dict[str, str]]: A list containing a single dictionary with:
+            List[Dict]: A list containing a single dictionary with:
                 - 'image': path to the chest X-ray image.
-                - 'labels': a list of binary labels (as strings) for the fourteen classes in ChestXray14Dataset.
+                - 'labels': a list of labels for diseases present in the image.
 
         Raises:
             ValueError: If the number of chestxray14 events is not exactly one.
@@ -61,4 +61,4 @@ class ChestXray14MultilabelClassification(BaseTask):
             raise ValueError(msg)
 
         from ..datasets.chestxray14 import ChestXray14Dataset # Avoid circular import
-        return [{"image": events[0]["path"], "labels": [events[0][disease] for disease in ChestXray14Dataset.classes]}]
+        return [{"image": events[0]["path"], "labels": [disease for disease in ChestXray14Dataset.classes if events[0][disease]]}]

--- a/pyhealth/tasks/chestxray14_multilabel_classification.py
+++ b/pyhealth/tasks/chestxray14_multilabel_classification.py
@@ -62,4 +62,4 @@ class ChestXray14MultilabelClassification(BaseTask):
 
         from ..datasets.chestxray14 import ChestXray14Dataset # Avoid circular import
         print(events[0])
-        return [{"image": events[0]["path"], "labels": [i for i, disease in enumerate(ChestXray14Dataset.classes) if events[0][disease]]}]
+        return [{"image": events[0]["path"], "labels": [i for i, disease in enumerate(ChestXray14Dataset.classes) if events[0][disease] == '1']}]

--- a/pyhealth/tasks/chestxray14_multilabel_classification.py
+++ b/pyhealth/tasks/chestxray14_multilabel_classification.py
@@ -61,5 +61,4 @@ class ChestXray14MultilabelClassification(BaseTask):
             raise ValueError(msg)
 
         from ..datasets.chestxray14 import ChestXray14Dataset # Avoid circular import
-        print(events[0])
-        return [{"image": events[0]["path"], "labels": [i for i, disease in enumerate(ChestXray14Dataset.classes) if events[0][disease] == '1']}]
+        return [{"image": events[0]["path"], "labels": [disease for disease in ChestXray14Dataset.classes if int(events[0][disease])]}]

--- a/pyhealth/tasks/chestxray14_multilabel_classification.py
+++ b/pyhealth/tasks/chestxray14_multilabel_classification.py
@@ -61,4 +61,5 @@ class ChestXray14MultilabelClassification(BaseTask):
             raise ValueError(msg)
 
         from ..datasets.chestxray14 import ChestXray14Dataset # Avoid circular import
+        print(events[0])
         return [{"image": events[0]["path"], "labels": [i for i, disease in enumerate(ChestXray14Dataset.classes) if events[0][disease]]}]

--- a/pyhealth/unittests/test_datasets/test_chestxray14.py
+++ b/pyhealth/unittests/test_datasets/test_chestxray14.py
@@ -14,7 +14,6 @@ import numpy as np
 from PIL import Image
 
 from ...datasets.chestxray14 import ChestXray14Dataset
-from ...tasks.chestxray14_binary_classification import ChestXray14BinaryClassification
 
 class TestChestXray14Dataset(unittest.TestCase):
     def setUp(self):
@@ -119,12 +118,14 @@ class TestChestXray14Dataset(unittest.TestCase):
         self.assertEqual(data['pneumothorax'], 0)
 
     def test_task_classify_cardiomegaly(self):
+        from ...tasks.chestxray14_binary_classification import ChestXray14BinaryClassification  # Avoid circular import
         task = ChestXray14BinaryClassification(disease="cardiomegaly")
         samples = self.dataset.set_task(task)
         self.assertEqual(len(samples), 10)
         self.assertEqual(sum(sample["label"] for sample in samples), 3)
 
     def test_task_classify_hernia(self):
+        from ...tasks.chestxray14_binary_classification import ChestXray14BinaryClassification  # Avoid circular import
         task = ChestXray14BinaryClassification(disease="hernia")
         samples = self.dataset.set_task(task)
         self.assertEqual(len(samples), 10)

--- a/pyhealth/unittests/test_datasets/test_chestxray14.py
+++ b/pyhealth/unittests/test_datasets/test_chestxray14.py
@@ -139,11 +139,10 @@ class TestChestXray14Dataset(unittest.TestCase):
         samples = self.dataset.set_task()
         self.assertEqual(len(samples), 10)
         for sample in samples:
-            print(sample)
             if '00000001_000.png' in sample['path']:
-                self.assertTrue(torch.equal(sample["labels"], torch.tensor([0.0, 0.0, 0.0, 0.0, 0.0])))
+                self.assertTrue(torch.equal(sample["labels"], torch.tensor([1.0, 0.0, 0.0, 0.0, 0.0])))
             elif '00000002_000.png' in sample['image']:
-                self.assertTrue(torch.equal(sample["path"], torch.tensor([1.0, 0.0, 0.0, 0.0, 0.0])))
+                self.assertTrue(torch.equal(sample["path"], torch.tensor([0.0, 0.0, 0.0, 0.0, 0.0])))
             elif '00000003_003.png' in sample['path']:
                 self.assertTrue(torch.equal(sample["labels"], torch.tensor([0.0, 0.0, 0.0, 1.0, 1.0])))
 

--- a/pyhealth/unittests/test_datasets/test_chestxray14.py
+++ b/pyhealth/unittests/test_datasets/test_chestxray14.py
@@ -14,6 +14,7 @@ import numpy as np
 from PIL import Image
 
 from ...datasets.chestxray14 import ChestXray14Dataset
+from ...tasks.chestxray14_binary_classification import ChestXray14BinaryClassification
 
 class TestChestXray14Dataset(unittest.TestCase):
     def setUp(self):
@@ -118,18 +119,20 @@ class TestChestXray14Dataset(unittest.TestCase):
         self.assertEqual(data['pneumothorax'], 0)
 
     def test_task_classify_cardiomegaly(self):
-        from ...tasks.chestxray14_binary_classification import ChestXray14BinaryClassification  # Avoid circular import
         task = ChestXray14BinaryClassification(disease="cardiomegaly")
         samples = self.dataset.set_task(task)
         self.assertEqual(len(samples), 10)
         self.assertEqual(sum(sample["label"] for sample in samples), 3)
 
     def test_task_classify_hernia(self):
-        from ...tasks.chestxray14_binary_classification import ChestXray14BinaryClassification  # Avoid circular import
         task = ChestXray14BinaryClassification(disease="hernia")
         samples = self.dataset.set_task(task)
         self.assertEqual(len(samples), 10)
         self.assertEqual(sum(sample["label"] for sample in samples), 6)
+
+    def test_dataset_and_task_classes_match(self):
+        # Must define list of classes in both the dataset and task to avoid circular import in this file
+        self.assertEqual(ChestXray14Dataset.classes, ChestXray14BinaryClassification.classes)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/pyhealth/unittests/test_datasets/test_chestxray14.py
+++ b/pyhealth/unittests/test_datasets/test_chestxray14.py
@@ -130,9 +130,5 @@ class TestChestXray14Dataset(unittest.TestCase):
         self.assertEqual(len(samples), 10)
         self.assertEqual(sum(sample["label"] for sample in samples), 6)
 
-    def test_dataset_and_task_classes_match(self):
-        # Must define list of classes in both the dataset and task to avoid circular import in this file
-        self.assertEqual(ChestXray14Dataset.classes, ChestXray14BinaryClassification.classes)
-
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/pyhealth/unittests/test_datasets/test_chestxray14.py
+++ b/pyhealth/unittests/test_datasets/test_chestxray14.py
@@ -138,12 +138,13 @@ class TestChestXray14Dataset(unittest.TestCase):
     def test_task_classify_all(self):
         samples = self.dataset.set_task()
         self.assertEqual(len(samples), 10)
-        print(samples[0])
-        print(samples[3])
-        print(samples[6])
-        self.assertTrue(torch.equal(samples[0]["labels"], torch.tensor([1])))
-        self.assertTrue(torch.equal(samples[3]["labels"], torch.tensor([])))
-        self.assertTrue(torch.equal(samples[6]["labels"], torch.tensor([7, 8])))
+        for sample in samples:
+            if '00000002_000.png' in sample['path']:
+                print(sample)
+            elif '00000001_000.png' in sample['path']:
+                print(sample)
+            elif '00000003_003.png' in sample['path']:
+                print(sample)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/pyhealth/unittests/test_datasets/test_chestxray14.py
+++ b/pyhealth/unittests/test_datasets/test_chestxray14.py
@@ -141,8 +141,8 @@ class TestChestXray14Dataset(unittest.TestCase):
         for sample in samples:
             if '00000001_000.png' in sample['path']:
                 self.assertTrue(torch.equal(sample["labels"], torch.tensor([1.0, 0.0, 0.0, 0.0, 0.0])))
-            elif '00000002_000.png' in sample['image']:
-                self.assertTrue(torch.equal(sample["path"], torch.tensor([0.0, 0.0, 0.0, 0.0, 0.0])))
+            elif '00000002_000.png' in sample['path']:
+                self.assertTrue(torch.equal(sample["labels"], torch.tensor([0.0, 0.0, 0.0, 0.0, 0.0])))
             elif '00000003_003.png' in sample['path']:
                 self.assertTrue(torch.equal(sample["labels"], torch.tensor([0.0, 0.0, 0.0, 1.0, 1.0])))
 

--- a/pyhealth/unittests/test_datasets/test_chestxray14.py
+++ b/pyhealth/unittests/test_datasets/test_chestxray14.py
@@ -138,9 +138,9 @@ class TestChestXray14Dataset(unittest.TestCase):
     def test_task_classify_all(self):
         samples = self.dataset.set_task()
         self.assertEqual(len(samples), 10)
-        self.assertEqual(samples[0]["labels"], torch.tensor([1]))
-        self.assertEqual(samples[3]["labels"], torch.tensor([]))
-        self.assertEqual(samples[6]["labels"], torch.tensor([7, 8]))
+        self.assertTrue(torch.equal(samples[0]["labels"], torch.tensor([1])))
+        self.assertTrue(torch.equal(samples[3]["labels"], torch.tensor([])))
+        self.assertTrue(torch.equal(samples[6]["labels"], torch.tensor([7, 8])))
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/pyhealth/unittests/test_datasets/test_chestxray14.py
+++ b/pyhealth/unittests/test_datasets/test_chestxray14.py
@@ -13,8 +13,8 @@ import unittest
 import numpy as np
 from PIL import Image
 
-from pyhealth.datasets.chestxray14 import ChestXray14Dataset
-from pyhealth.tasks.chestxray14_binary_classification import ChestXray14BinaryClassification
+from ...datasets.chestxray14 import ChestXray14Dataset
+from ...tasks.chestxray14_binary_classification import ChestXray14BinaryClassification
 
 class TestChestXray14Dataset(unittest.TestCase):
     def setUp(self):

--- a/pyhealth/unittests/test_datasets/test_chestxray14.py
+++ b/pyhealth/unittests/test_datasets/test_chestxray14.py
@@ -15,6 +15,7 @@ from PIL import Image
 
 from ...datasets.chestxray14 import ChestXray14Dataset
 from ...tasks.chestxray14_binary_classification import ChestXray14BinaryClassification
+from ...tasks.chestxray14_multilabel_classification import ChestXray14MultilabelClassification
 
 class TestChestXray14Dataset(unittest.TestCase):
     def setUp(self):
@@ -118,6 +119,9 @@ class TestChestXray14Dataset(unittest.TestCase):
         self.assertEqual(data['pneumonia'], 0)
         self.assertEqual(data['pneumothorax'], 0)
 
+    def test_default_task(self):
+        self.assertEqual(self.dataset.default_task, ChestXray14MultilabelClassification)
+
     def test_task_classify_cardiomegaly(self):
         task = ChestXray14BinaryClassification(disease="cardiomegaly")
         samples = self.dataset.set_task(task)
@@ -129,6 +133,13 @@ class TestChestXray14Dataset(unittest.TestCase):
         samples = self.dataset.set_task(task)
         self.assertEqual(len(samples), 10)
         self.assertEqual(sum(sample["label"] for sample in samples), 6)
+
+    def test_task_classify_all(self):
+        samples = self.dataset.set_task()
+        self.assertEqual(len(samples), 10)
+        self.assertEqual(samples[0]["labels"], [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        self.assertEqual(samples[3]["labels"], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        self.assertEqual(samples[6]["labels"], [0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0])
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/pyhealth/unittests/test_datasets/test_chestxray14.py
+++ b/pyhealth/unittests/test_datasets/test_chestxray14.py
@@ -138,6 +138,9 @@ class TestChestXray14Dataset(unittest.TestCase):
     def test_task_classify_all(self):
         samples = self.dataset.set_task()
         self.assertEqual(len(samples), 10)
+        print(samples[0])
+        print(samples[3])
+        print(samples[6])
         self.assertTrue(torch.equal(samples[0]["labels"], torch.tensor([1])))
         self.assertTrue(torch.equal(samples[3]["labels"], torch.tensor([])))
         self.assertTrue(torch.equal(samples[6]["labels"], torch.tensor([7, 8])))

--- a/pyhealth/unittests/test_datasets/test_chestxray14.py
+++ b/pyhealth/unittests/test_datasets/test_chestxray14.py
@@ -140,11 +140,11 @@ class TestChestXray14Dataset(unittest.TestCase):
         self.assertEqual(len(samples), 10)
         for sample in samples:
             print(sample)
-            if '00000001_000.png' in sample['image']:
+            if '00000001_000.png' in sample['path']:
                 self.assertTrue(torch.equal(sample["labels"], torch.tensor([0.0, 0.0, 0.0, 0.0, 0.0])))
             elif '00000002_000.png' in sample['image']:
-                self.assertTrue(torch.equal(sample["labels"], torch.tensor([1.0, 0.0, 0.0, 0.0, 0.0])))
-            elif '00000003_003.png' in sample['image']:
+                self.assertTrue(torch.equal(sample["path"], torch.tensor([1.0, 0.0, 0.0, 0.0, 0.0])))
+            elif '00000003_003.png' in sample['path']:
                 self.assertTrue(torch.equal(sample["labels"], torch.tensor([0.0, 0.0, 0.0, 1.0, 1.0])))
 
 if __name__ == "__main__":

--- a/pyhealth/unittests/test_datasets/test_chestxray14.py
+++ b/pyhealth/unittests/test_datasets/test_chestxray14.py
@@ -1,5 +1,5 @@
 """
-Unit tests for the ChestXray14Dataset and ChestXray14BinaryClassification classes.
+Unit tests for the ChestXray14Dataset, ChestXray14BinaryClassification, and ChestXray14MultilabelClassification classes.
 
 Author:
     Eric Schrock (ejs9@illinois.edu)
@@ -120,7 +120,7 @@ class TestChestXray14Dataset(unittest.TestCase):
         self.assertEqual(data['pneumothorax'], 0)
 
     def test_default_task(self):
-        self.assertEqual(self.dataset.default_task, ChestXray14MultilabelClassification)
+        self.assertIsInstance(self.dataset.default_task, ChestXray14MultilabelClassification)
 
     def test_task_classify_cardiomegaly(self):
         task = ChestXray14BinaryClassification(disease="cardiomegaly")
@@ -137,9 +137,9 @@ class TestChestXray14Dataset(unittest.TestCase):
     def test_task_classify_all(self):
         samples = self.dataset.set_task()
         self.assertEqual(len(samples), 10)
-        self.assertEqual(samples[0]["labels"], [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-        self.assertEqual(samples[3]["labels"], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-        self.assertEqual(samples[6]["labels"], [0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0])
+        self.assertEqual(samples[0]["labels"], ['cardiomegaly'])
+        self.assertEqual(samples[3]["labels"], [])
+        self.assertEqual(samples[6]["labels"], ['hernia', 'infiltration'])
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/pyhealth/unittests/test_datasets/test_chestxray14.py
+++ b/pyhealth/unittests/test_datasets/test_chestxray14.py
@@ -12,6 +12,7 @@ import unittest
 
 import numpy as np
 from PIL import Image
+import torch
 
 from ...datasets.chestxray14 import ChestXray14Dataset
 from ...tasks.chestxray14_binary_classification import ChestXray14BinaryClassification
@@ -137,9 +138,9 @@ class TestChestXray14Dataset(unittest.TestCase):
     def test_task_classify_all(self):
         samples = self.dataset.set_task()
         self.assertEqual(len(samples), 10)
-        self.assertEqual(samples[0]["labels"], ['cardiomegaly'])
-        self.assertEqual(samples[3]["labels"], [])
-        self.assertEqual(samples[6]["labels"], ['hernia', 'infiltration'])
+        self.assertEqual(samples[0]["labels"], torch.tensor([1]))
+        self.assertEqual(samples[3]["labels"], torch.tensor([]))
+        self.assertEqual(samples[6]["labels"], torch.tensor([7, 8]))
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/pyhealth/unittests/test_datasets/test_chestxray14.py
+++ b/pyhealth/unittests/test_datasets/test_chestxray14.py
@@ -139,12 +139,13 @@ class TestChestXray14Dataset(unittest.TestCase):
         samples = self.dataset.set_task()
         self.assertEqual(len(samples), 10)
         for sample in samples:
-            if '00000002_000.png' in sample['path']:
-                print(sample)
-            elif '00000001_000.png' in sample['path']:
-                print(sample)
-            elif '00000003_003.png' in sample['path']:
-                print(sample)
+            print(sample)
+            if '00000001_000.png' in sample['image']:
+                self.assertTrue(torch.equal(sample["labels"], torch.tensor([0.0, 0.0, 0.0, 0.0, 0.0])))
+            elif '00000002_000.png' in sample['image']:
+                self.assertTrue(torch.equal(sample["labels"], torch.tensor([1.0, 0.0, 0.0, 0.0, 0.0])))
+            elif '00000003_003.png' in sample['image']:
+                self.assertTrue(torch.equal(sample["labels"], torch.tensor([0.0, 0.0, 0.0, 1.0, 1.0])))
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Changes
1. Switched to relative `pyhealth` imports
2. Added dataset and task classes to `dataset/__init__.py` and `tasks/__init__.py`
3. Changed `ChestXray14Dataset.stat()` to `ChestXray14Dataset.stats()` to override base class `stats` method and added more statistics to the output
4. Added `ChestXray14MultilabelClassification` and associated tests
5. Set `ChestXray14MultilabelClassification` as the default task for `ChestXray14Dataset`

## Testing
```sh
pip install numpy==1.26.4
pip install pandas==1.5.3
pip install mne pandarallel rdkit transformers
git clone https://github.com/EricSchrock/PyHealth.git
cd PyHealth
git checkout fix-internal-imports
pip install .
python -m pyhealth.unittests.test_datasets.test_chestxray14
python -m pyhealth.datasets.chestxray14 --config "pyhealth/datasets/configs/chestxray14.yaml" --download --partial
```