### PR TITLE
Address Copilot PR feedback

### DIFF
--- a/pyhealth/datasets/chestxray14.py
+++ b/pyhealth/datasets/chestxray14.py
@@ -45,7 +45,7 @@ class ChestXray14Dataset(BaseDataset):
     Methods:
         __len__(): Returns the number of entries in the dataset.
         __getitem__(index: int): Retrieves a specific image and its metadata.
-        stat(): Prints statistics about the dataset's content.
+        stats(): Prints statistics about the dataset's content.
     """
     classes: List[str] = ["atelectasis", "cardiomegaly", "consolidation",
                "edema", "effusion", "emphysema",

--- a/pyhealth/datasets/chestxray14.py
+++ b/pyhealth/datasets/chestxray14.py
@@ -235,7 +235,7 @@ class ChestXray14Dataset(BaseDataset):
                 file_md5 = hashlib.md5(f.read()).hexdigest()
 
             if file_md5 != md5_checksums[idx]:
-                msg = "Invalid MD5 checksum"
+                msg = "Invalid MD5 checksum!"
                 logger.error(msg)
                 raise ValueError(msg)
 
@@ -249,7 +249,7 @@ class ChestXray14Dataset(BaseDataset):
                 for member in tar.getmembers():
                     member_path = os.path.join(root, member.name)
                     if not is_within_directory(root, member_path):
-                        msg = f"Unsafe path detected in tar file: '{member.name}'"
+                        msg = f"Unsafe path detected in tar file: '{member.name}'!"
                         logger.error(msg)
                         raise ValueError(msg)
 

--- a/pyhealth/tasks/chestxray14_binary_classification.py
+++ b/pyhealth/tasks/chestxray14_binary_classification.py
@@ -52,7 +52,7 @@ class ChestXray14BinaryClassification(BaseTask):
         """
         from ..datasets.chestxray14 import ChestXray14Dataset # Avoid circular import
         if disease not in ChestXray14Dataset.classes:
-            msg = f"Invalid disease: {disease}! Must be one of {ChestXray14Dataset.classes}."
+            msg = f"Invalid disease: '{disease}'! Must be one of {ChestXray14Dataset.classes}."
             logger.error(msg)
             raise ValueError(msg)
 

--- a/pyhealth/tasks/chestxray14_binary_classification.py
+++ b/pyhealth/tasks/chestxray14_binary_classification.py
@@ -52,7 +52,7 @@ class ChestXray14BinaryClassification(BaseTask):
         """
         from ..datasets.chestxray14 import ChestXray14Dataset # Avoid circular import
         if disease not in ChestXray14Dataset.classes:
-            msg = "Invalid disease!"
+            msg = f"Invalid disease: {disease}! Must be one of {ChestXray14Dataset.classes}."
             logger.error(msg)
             raise ValueError(msg)
 

--- a/pyhealth/tasks/chestxray14_multilabel_classification.py
+++ b/pyhealth/tasks/chestxray14_multilabel_classification.py
@@ -50,7 +50,7 @@ class ChestXray14MultilabelClassification(BaseTask):
             List[Dict]: A list containing a single dictionary with:
                 - 'image': path to the chest X-ray image.
                 - 'path': path to the chest X-ray image (excluded from the input and output schemas and used for testing).
-                - 'labels': a list of labels for diseases present in the image (0-based indices of ChestXray14Dataset.classes).
+                - 'labels': a list of labels for diseases present in the image (strings from the list ChestXray14Dataset.classes).
 
         Raises:
             ValueError: If the number of chestxray14 events is not exactly one.

--- a/pyhealth/tasks/chestxray14_multilabel_classification.py
+++ b/pyhealth/tasks/chestxray14_multilabel_classification.py
@@ -49,7 +49,6 @@ class ChestXray14MultilabelClassification(BaseTask):
         Returns:
             List[Dict]: A list containing a single dictionary with:
                 - 'image': path to the chest X-ray image.
-                - 'path': path to the chest X-ray image (excluded from the input and output schemas and used for testing).
                 - 'labels': a list of labels for diseases present in the image (strings from the list ChestXray14Dataset.classes).
 
         Raises:
@@ -62,4 +61,4 @@ class ChestXray14MultilabelClassification(BaseTask):
             raise ValueError(msg)
 
         from ..datasets.chestxray14 import ChestXray14Dataset # Avoid circular import
-        return [{"image": events[0]["path"], "path": events[0]["path"], "labels": [disease for disease in ChestXray14Dataset.classes if int(events[0][disease])]}]
+        return [{"image": events[0]["path"], "labels": [disease for disease in ChestXray14Dataset.classes if int(events[0][disease])]}]

--- a/pyhealth/unittests/test_datasets/test_chestxray14.py
+++ b/pyhealth/unittests/test_datasets/test_chestxray14.py
@@ -25,17 +25,17 @@ class TestChestXray14Dataset(unittest.TestCase):
 
         # Source: https://nihcc.app.box.com/v/ChestXray-NIHCC/file/219760887468
         lines = [
-            "Image Index,Finding Labels,Follow-up #,Patient ID,Patient Age,Patient Sex,View Position,OriginalImage[Width,Height],OriginalImagePixelSpacing[x",
-            "00000001_000.png,Cardiomegaly,0,1,57,M,PA,2682,2749,0.14300000000000002",
-            "00000001_001.png,Cardiomegaly|Emphysema,1,1,58,M,PA,2894,2729,0.14300000000000002",
-            "00000001_002.png,Cardiomegaly|Effusion,2,1,58,M,PA,2500,2048,0.168",
-            "00000002_000.png,No Finding,0,2,80,M,PA,2500,2048,0.171",
-            "00000003_001.png,Hernia,0,3,74,F,PA,2500,2048,0.168",
-            "00000003_002.png,Hernia,1,3,75,F,PA,2048,2500,0.168",
-            "00000003_003.png,Hernia|Infiltration,2,3,76,F,PA,2698,2991,0.14300000000000002",
-            "00000003_004.png,Hernia,3,3,77,F,PA,2500,2048,0.168",
-            "00000003_005.png,Hernia,4,3,78,F,PA,2686,2991,0.14300000000000002",
-            "00000003_006.png,Hernia,5,3,79,F,PA,2992,2991,0.14300000000000002",
+            "Image Index,Finding Labels,Follow-up #,Patient ID,Patient Age,Patient Sex,View Position,OriginalImage[Width,Height],OriginalImagePixelSpacing[x,y],",
+            "00000001_000.png,Cardiomegaly,0,1,57,M,PA,2682,2749,0.14300000000000002,0.14300000000000002,",
+            "00000001_001.png,Cardiomegaly|Emphysema,1,1,58,M,PA,2894,2729,0.14300000000000002,0.14300000000000002,",
+            "00000001_002.png,Cardiomegaly|Effusion,2,1,58,M,PA,2500,2048,0.168,0.168,",
+            "00000002_000.png,No Finding,0,2,80,M,PA,2500,2048,0.171,0.171,",
+            "00000003_001.png,Hernia,0,3,74,F,PA,2500,2048,0.168,0.168,",
+            "00000003_002.png,Hernia,1,3,75,F,PA,2048,2500,0.168,0.168,",
+            "00000003_003.png,Hernia|Infiltration,2,3,76,F,PA,2698,2991,0.14300000000000002,0.14300000000000002,",
+            "00000003_004.png,Hernia,3,3,77,F,PA,2500,2048,0.168,0.168,",
+            "00000003_005.png,Hernia,4,3,78,F,PA,2686,2991,0.14300000000000002,0.14300000000000002,",
+            "00000003_006.png,Hernia,5,3,79,F,PA,2992,2991,0.14300000000000002,0.14300000000000002,",
         ]
 
         # Create mock images to test image loading

--- a/pyhealth/unittests/test_datasets/test_chestxray14.py
+++ b/pyhealth/unittests/test_datasets/test_chestxray14.py
@@ -23,34 +23,30 @@ class TestChestXray14Dataset(unittest.TestCase):
         os.mkdir("test")
         os.mkdir("test/images")
 
-        images = [
-            "00000001_000.png",
-            "00000001_001.png",
-            "00000001_002.png",
-            "00000002_000.png",
-            "00000003_001.png",
-            "00000003_002.png",
-            "00000003_003.png",
-            "00000003_004.png",
-            "00000003_005.png",
-            "00000003_006.png"
+        # Source: https://nihcc.app.box.com/v/ChestXray-NIHCC/file/219760887468
+        lines = [
+            "Image Index,Finding Labels,Follow-up #,Patient ID,Patient Age,Patient Sex,View Position,OriginalImage[Width,Height],OriginalImagePixelSpacing[x",
+            "00000001_000.png,Cardiomegaly,0,1,57,M,PA,2682,2749,0.14300000000000002",
+            "00000001_001.png,Cardiomegaly|Emphysema,1,1,58,M,PA,2894,2729,0.14300000000000002",
+            "00000001_002.png,Cardiomegaly|Effusion,2,1,58,M,PA,2500,2048,0.168",
+            "00000002_000.png,No Finding,0,2,80,M,PA,2500,2048,0.171",
+            "00000003_001.png,Hernia,0,3,74,F,PA,2500,2048,0.168",
+            "00000003_002.png,Hernia,1,3,75,F,PA,2048,2500,0.168",
+            "00000003_003.png,Hernia|Infiltration,2,3,76,F,PA,2698,2991,0.14300000000000002",
+            "00000003_004.png,Hernia,3,3,77,F,PA,2500,2048,0.168",
+            "00000003_005.png,Hernia,4,3,78,F,PA,2686,2991,0.14300000000000002",
+            "00000003_006.png,Hernia,5,3,79,F,PA,2992,2991,0.14300000000000002",
         ]
 
-        for name in images:
+        # Create mock images to test image loading
+        for line in lines[1:]: # Skip header row
+            name = line.split(',')[0]
             img = Image.fromarray(np.random.randint(0, 256, (224, 224, 4), dtype=np.uint8), mode="RGBA")
             img.save(os.path.join("test/images", name))
 
-        # https://nihcc.app.box.com/v/ChestXray-NIHCC/file/219760887468 (mirrored to Google Drive)
-        # I couldn't figure out a way to download this file directly from box.com
-        response = requests.get('https://drive.google.com/uc?export=download&id=1mkOZNfYt-Px52b8CJZJANNbM3ULUVO3f')
-        with open("test/Data_Entry_2017_v2020.csv", "wb") as file:
-            file.write(response.content)
-
-        with open("test/Data_Entry_2017_v2020.csv", 'r') as f:
-            lines = f.readlines()
-
+        # Save image labels to file
         with open("test/Data_Entry_2017_v2020.csv", 'w') as f:
-            f.writelines(lines[:11])
+            f.writelines(lines)
 
         self.dataset = ChestXray14Dataset(root="./test", config_path=str(Path(__file__).parent.parent.parent / "datasets" / "configs" / "chestxray14.yaml"), download=False, partial=True)
 

--- a/pyhealth/unittests/test_datasets/test_chestxray14.py
+++ b/pyhealth/unittests/test_datasets/test_chestxray14.py
@@ -20,8 +20,9 @@ from ...tasks.chestxray14_multilabel_classification import ChestXray14Multilabel
 
 class TestChestXray14Dataset(unittest.TestCase):
     def setUp(self):
-        os.mkdir("test")
-        os.mkdir("test/images")
+        if os.path.exists("test"):
+            shutil.rmtree("test")
+        os.makedirs("test/images")
 
         # Source: https://nihcc.app.box.com/v/ChestXray-NIHCC/file/219760887468
         lines = [
@@ -46,12 +47,13 @@ class TestChestXray14Dataset(unittest.TestCase):
 
         # Save image labels to file
         with open("test/Data_Entry_2017_v2020.csv", 'w') as f:
-            f.writelines(lines)
+            f.write("\n".join(lines))
 
         self.dataset = ChestXray14Dataset(root="./test", config_path=str(Path(__file__).parent.parent.parent / "datasets" / "configs" / "chestxray14.yaml"), download=False, partial=True)
 
     def tearDown(self):
-        shutil.rmtree("test")
+        if os.path.exists("test"):
+            shutil.rmtree("test")
 
     def test_len(self):
         self.assertEqual(len(self.dataset), 10)

--- a/pyhealth/unittests/test_datasets/test_chestxray14.py
+++ b/pyhealth/unittests/test_datasets/test_chestxray14.py
@@ -6,13 +6,11 @@ Author:
 """
 import os
 from pathlib import Path
-import requests
 import shutil
 import unittest
 
 import numpy as np
 from PIL import Image
-import torch
 
 from ...datasets.chestxray14 import ChestXray14Dataset
 from ...tasks.chestxray14_binary_classification import ChestXray14BinaryClassification

--- a/pyhealth/unittests/test_datasets/test_chestxray14.py
+++ b/pyhealth/unittests/test_datasets/test_chestxray14.py
@@ -140,13 +140,23 @@ class TestChestXray14Dataset(unittest.TestCase):
     def test_task_classify_all(self):
         samples = self.dataset.set_task()
         self.assertEqual(len(samples), 10)
-        for sample in samples:
-            if '00000001_000.png' in sample['path']:
-                self.assertTrue(torch.equal(sample["labels"], torch.tensor([1.0, 0.0, 0.0, 0.0, 0.0])))
-            elif '00000002_000.png' in sample['path']:
-                self.assertTrue(torch.equal(sample["labels"], torch.tensor([0.0, 0.0, 0.0, 0.0, 0.0])))
-            elif '00000003_003.png' in sample['path']:
-                self.assertTrue(torch.equal(sample["labels"], torch.tensor([0.0, 0.0, 0.0, 1.0, 1.0])))
+
+        actual_labels = [sample["labels"].tolist() for sample in samples]
+
+        expected_labels = [
+            [1.0, 0.0, 0.0, 0.0, 0.0],
+            [1.0, 0.0, 1.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0, 1.0],
+            [0.0, 0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0, 0.0],
+        ]
+
+        self.assertCountEqual(actual_labels, expected_labels)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/pyhealth/unittests/test_datasets/test_chestxray14.py
+++ b/pyhealth/unittests/test_datasets/test_chestxray14.py
@@ -37,7 +37,7 @@ class TestChestXray14Dataset(unittest.TestCase):
         ]
 
         for name in images:
-            img = Image.fromarray(np.random.randint(0, 256, (224, 224, 4), dtype=np.uint8), mode="RGB")
+            img = Image.fromarray(np.random.randint(0, 256, (224, 224, 4), dtype=np.uint8), mode="RGBA")
             img.save(os.path.join("test/images", name))
 
         # https://nihcc.app.box.com/v/ChestXray-NIHCC/file/219760887468 (mirrored to Google Drive)

--- a/pyhealth/unittests/test_datasets/test_chestxray14.py
+++ b/pyhealth/unittests/test_datasets/test_chestxray14.py
@@ -119,6 +119,10 @@ class TestChestXray14Dataset(unittest.TestCase):
     def test_default_task(self):
         self.assertIsInstance(self.dataset.default_task, ChestXray14MultilabelClassification)
 
+    def test_task_given_invalid_disease(self):
+        with self.assertRaises(ValueError):
+            _ = ChestXray14BinaryClassification(disease="toothache")
+
     def test_task_classify_cardiomegaly(self):
         task = ChestXray14BinaryClassification(disease="cardiomegaly")
         samples = self.dataset.set_task(task)


### PR DESCRIPTION
- Protect against zip-slips when extracting image TAR files
- Remove need for network requests during unit testing
- Add unit test for initializing binary classification task with an invalid disease
- Remove need for extra test data in multilabel classification task samples
- Other minor fixes